### PR TITLE
Updated the shebang headers.

### DIFF
--- a/generate_cpu_db.py
+++ b/generate_cpu_db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import requests
 import json

--- a/generate_gpu_db.py
+++ b/generate_gpu_db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import requests
 import json

--- a/map_scores.py
+++ b/map_scores.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import json
 from pprint import pprint
 

--- a/scrape.py
+++ b/scrape.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import requests
 from bs4 import BeautifulSoup


### PR DESCRIPTION
/usr/bin/env python3 is more versatile. And supports having python in other than the default path.